### PR TITLE
support cusdis

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -162,7 +162,7 @@ export const NotionPage: React.FC<types.PageProps> = ({
             appId: config.cusdis.appId,
             pageId: pageId,
             pageTitle: title,
-            pageUrl: typeof location !== undefined ? location.href : undefined
+            pageUrl: typeof location !== 'undefined' ? location.href : undefined
           }}
         ></ReactCusdis>
       )

--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -160,9 +160,9 @@ export const NotionPage: React.FC<types.PageProps> = ({
           attrs={{
             host: config.cusdis.host || 'https://cusdis.com',
             appId: config.cusdis.appId,
-            pageId: site.name,
-            pageTitle: site.name,
-            pageUrl: site.domain
+            pageId: pageId,
+            pageTitle: title,
+            pageUrl: typeof location !== undefined ? location.href : undefined
           }}
         ></ReactCusdis>
       )

--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -34,7 +34,7 @@ import { Footer } from './Footer'
 import { PageSocial } from './PageSocial'
 import { GitHubShareButton } from './GitHubShareButton'
 import { ReactUtterances } from './ReactUtterances'
-
+import { ReactCusdis } from 'react-cusdis'
 import styles from './styles.module.css'
 
 // const Code = dynamic(() =>
@@ -147,6 +147,24 @@ export const NotionPage: React.FC<types.PageProps> = ({
           issueTerm='title'
           theme={darkMode.value ? 'photon-dark' : 'github-light'}
         />
+      )
+    } else if (config.cusdis) {
+      if (!config.cusdis.appId) {
+        console.warn('[cusdis]', 'appId is required')
+      }
+      comments = (
+        <ReactCusdis
+          style={{
+            width: "100%"
+          }}
+          attrs={{
+            host: config.cusdis.host || 'https://cusdis.com',
+            appId: config.cusdis.appId,
+            pageId: site.name,
+            pageTitle: site.name,
+            pageUrl: site.domain
+          }}
+        ></ReactCusdis>
       )
     }
 

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -76,6 +76,12 @@ export const utterancesGitHubRepo: string | null = getSiteConfig(
   null
 )
 
+// Optional Cusdis widget https://cusdis.com
+export const cusdis = getSiteConfig(
+  'cusdis',
+  null
+)
+
 // Optional image CDN host to proxy all image requests through
 export const imageCDNHost: string | null = getSiteConfig('imageCDNHost', null)
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "p-memoize": "^4.0.0",
     "react": "^17.0.2",
     "react-body-classname": "^1.3.1",
+    "react-cusdis": "^1.0.1",
     "react-dom": "^17.0.2",
     "react-icons": "^4.1.0",
     "react-notion-x": "^4.5.0",

--- a/site.config.js
+++ b/site.config.js
@@ -34,6 +34,9 @@ module.exports = {
   // Utteranc.es comments via GitHub issue comments (optional)
   utterancesGitHubRepo: null,
 
+  // Cusdis comment widget (optional)
+  cusdis: null,
+
   // whether or not to enable support for LQIP preview images (optional)
   // NOTE: this requires you to set up Google Firebase and add the environment
   // variables specified in .env.example


### PR DESCRIPTION
[Cusdis](https://cusdis.com) is an open-source, lightweight, privacy-friendly alternative to Disqus. We'd like to integrate it in nextjs-notion-starter-kit 🥰

Ref: https://github.com/djyde/cusdis/issues/22#issuecomment-824060612

See the result and usage: https://cusdis-nextjs-notion-starter.vercel.app/