### PR TITLE
Fix spelling on "Tottle darkmode"

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -33,7 +33,7 @@ export const Footer: React.FC<{
           <a
             className={styles.toggleDarkMode}
             onClick={toggleDarkModeCb}
-            title='Tottle dark mode'
+            title='Toggle dark mode'
           >
             {isDarkMode ? <IoMoonSharp /> : <IoSunnyOutline />}
           </a>


### PR DESCRIPTION
<!--
If applicable, please include a link to at least one publicly accessible Notion page related to your issue.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->

It ain't much but it's been bugging me for a while. Just fixed the spelling on Footer.tsx so it says "Toggle dark mode" instead of "Tottle dark mode"
