### PR TITLE
Fix Inline Code display issue on Light/Dark themes

### DIFF
--- a/styles/prism-theme.css
+++ b/styles/prism-theme.css
@@ -21,6 +21,19 @@
 .dark-mode .notion code {
   color: rgba(229, 231, 235, 1);
 }
+
+.dark-mode .notion .notion-inline-code {
+  background: rgb(71,76,80) !important;
+  color: #ff4081;
+  padding: .2em .4em !important;
+}
+
+.light-mode .notion .notion-inline-code {
+  color: #ff4081;
+  background: rgba(55,53,47, .1) !important;
+  padding: .2em .4em !important;
+}
+
 .token.cdata,
 .token.doctype,
 .token.prolog {


### PR DESCRIPTION
<!--
If applicable, please include a link to at least one publicly accessible Notion page related to your issue.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
While multi-line code blocks look OK, Inline Code styling appears to be currently broken on both Light and Dark mode.

I added styling fixes for both light and dark mode that look more in line with Notion's styling.

Here's what it looks like before/after:

Light Mode:
![lightMode](https://user-images.githubusercontent.com/4033621/132151152-516a198b-072f-4054-b3eb-0aac68c02054.png)
![lightModeFixed](https://user-images.githubusercontent.com/4033621/132151159-aeabc25d-727f-468d-8708-19de53a4885c.png)

Dark Mode:
![darkModeBroken](https://user-images.githubusercontent.com/4033621/132151364-d2a2760b-a5aa-49a3-84b6-02a1f216b2d4.jpg)
![darkModeFixed](https://user-images.githubusercontent.com/4033621/132151175-649fbd68-4500-40d7-8f56-9460aff4b3a0.png)




