### PR TITLE
fix: embedded video no longer overflows

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -1,7 +1,7 @@
 /**
  * This file contains site-specifc style overrides for Notion elements from
  * react-notion-x.
- * 
+ *
  * react-notion-x's goal is to match styling as close as possible to Notion,
  * whereas our goal with this site is to adjust Notion's styling in a few key
  * places to add some flare.
@@ -33,6 +33,13 @@
   margin-top: 1em;
   margin-bottom: 1em;
 }
+
+/* <-- Fix embedded video's size overflows its container */
+.notion-asset-wrapper-video > div,
+.notion-asset-wrapper-video video {
+  width: 100% !important;
+}
+/* Fix embedded video's size overflows its container --> */
 
 .notion-header .nav-header {
   max-width: 1100px;


### PR DESCRIPTION
<!--
If applicable, please include a link to at least one publicly accessible Notion page related to your issue.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
## Issue
Fix #162 

Notion page with issue: https://andrewnt.notion.site/Using-backface-visiblity-in-flipping-cards-73d9a23ff1ca410e9c20d3ab4c6f1dbd

## Description

This CSS constrains the width of the embedded video to 100% of its container `.notion-page-content-inner`

![image](https://user-images.githubusercontent.com/52666982/138357326-1df2cfef-7880-4829-aa40-9b4248e9b3bd.png)

### Hacktoberfest

If you find this PR helpful, adding the label `hacktoberfest-accepted` will be greatly appreciated.