### PR TITLE
feat: generate sitemap only on overridden urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 .DS_Store
 *.pem
 
+# ide
+.idea
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/api/sitemap.xml.ts
+++ b/api/sitemap.xml.ts
@@ -1,8 +1,10 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import { SiteMap } from '../lib/types'
-import { host } from '../lib/config'
-import { getSiteMaps } from '../lib/get-site-maps'
+import { host, sitemapOnlyPageUrlOverridden } from '../lib/config'
+import { getOnlyUrlOverriddenSiteMaps, getSiteMaps } from '../lib/get-site-maps'
+import * as config  from '../lib/config'
+import * as types from '../lib/types'
 
 export default async (
   req: NextApiRequest,
@@ -12,7 +14,12 @@ export default async (
     return res.status(405).send({ error: 'method not allowed' })
   }
 
-  const siteMaps = await getSiteMaps()
+  let siteMaps: types.SiteMap[]
+  if (sitemapOnlyPageUrlOverridden) {
+    siteMaps = await getOnlyUrlOverriddenSiteMaps()
+  } else {
+    siteMaps = await getSiteMaps()
+  }
 
   // cache sitemap for up to one hour
   res.setHeader(

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -36,6 +36,8 @@ export const pageUrlAdditions = cleanPageUrlMap(
   'pageUrlAdditions'
 )
 
+export const sitemapOnlyPageUrlOverridden = getSiteConfig('sitemapOnlyPageUrlOverridden')
+
 // general site config
 export const name: string = getSiteConfig('name')
 export const author: string = getSiteConfig('author')

--- a/lib/get-site-maps.ts
+++ b/lib/get-site-maps.ts
@@ -37,12 +37,14 @@ export async function getSiteMaps(): Promise<types.SiteMap[]> {
 
 export async function getOnlyUrlOverriddenSiteMaps(): Promise<types.SiteMap[]> {
   return (await getSiteMaps()).map(sm => {
-    sm.canonicalPageMap = Object.entries(sm.canonicalPageMap).reduce((acc, [cp_name, cp_value]) => {
-      if (config.pageUrlOverrides[cp_name]) {
-        acc[cp_name] = cp_value
-      }
-      return acc
-    }, {})
-    return sm
+    return {
+      ...sm,
+      canonicalPageMap: Object.entries(sm.canonicalPageMap).reduce((acc, [cp_name, cp_value]) => {
+        if (config.pageUrlOverrides[cp_name]) {
+          acc[cp_name] = cp_value
+        }
+        return acc
+      }, {})
+    }
   })
 }

--- a/lib/get-site-maps.ts
+++ b/lib/get-site-maps.ts
@@ -3,6 +3,7 @@ import pMap from 'p-map'
 import { getAllPages } from './get-all-pages'
 import { getSites } from './get-sites'
 import * as types from './types'
+import * as config from "./config"
 
 export async function getSiteMaps(): Promise<types.SiteMap[]> {
   const sites = await getSites()
@@ -32,4 +33,16 @@ export async function getSiteMaps(): Promise<types.SiteMap[]> {
   )
 
   return siteMaps.filter(Boolean)
+}
+
+export async function getOnlyUrlOverriddenSiteMaps(): Promise<types.SiteMap[]> {
+  return (await getSiteMaps()).map(sm => {
+    sm.canonicalPageMap = Object.entries(sm.canonicalPageMap).reduce((acc, [cp_name, cp_value]) => {
+      if (config.pageUrlOverrides[cp_name]) {
+        acc[cp_name] = cp_value
+      }
+      return acc
+    }, {})
+    return sm
+  })
 }

--- a/site.config.js
+++ b/site.config.js
@@ -47,5 +47,10 @@ module.exports = {
   //   '/foo': '067dd719a912471ea9a3ac10710e7fdf',
   //   '/bar': '0be6efce9daf42688f65c76b89f8eb27'
   // }
-  pageUrlOverrides: null
+  pageUrlOverrides: null,
+
+  // if you want to generate sitemap.xml only with url overrided
+  // by `pageUrlOverrides` prop, that will make SEO robots only to
+  // index pages that urls have been overridden
+  sitemapOnlyPageUrlOverridden: false
 }


### PR DESCRIPTION
It's needed if you don't want SEO crawlers to index not overridden urls, because:

1. Your page titles are on different language, so urls will be ugly
2. You want to make not overridden pages private

! Depends on #186