### PR TITLE
fix: add header background for dark mode

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -327,7 +327,7 @@
 }
 
 .dark-mode .notion-header {
-  background: transparent;
+  background: hsla(203, 8%, 20%, 0.8);
   box-shadow: inset 0 -1px 0 0 rgba(0, 0, 0, 0.1);
   backdrop-filter: saturate(180%) blur(8px);
 }

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -327,9 +327,16 @@
 }
 
 .dark-mode .notion-header {
-  background: hsla(203, 8%, 20%, 0.8);
+  background: transparent;
   box-shadow: inset 0 -1px 0 0 rgba(0, 0, 0, 0.1);
   backdrop-filter: saturate(180%) blur(8px);
+}
+
+/* Workaround for Firefox not supporting backdrop-filter yet */
+@-moz-document url-prefix() {
+  .dark-mode .notion-header {
+    background: hsla(203, 8%, 20%, 0.8);
+  }
 }
 
 .notion-bookmark:hover {


### PR DESCRIPTION
The current transparent dark mode notion header is not very readable when scrolling above text or images with light color.
![current_header](https://user-images.githubusercontent.com/10750070/161294311-3a2d8924-a7e5-4b88-b309-89a59c0966ef.png)

This PR adds dark mode background to the notion header in the same way as it already is in light mode.
![fixed_header](https://user-images.githubusercontent.com/10750070/161294334-ab8fcc3d-a1e5-4510-aee4-99f6da8e5157.png)

