### PR TITLE
Fix background colors margin + fix dark mode

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -221,7 +221,7 @@
 .notion-brown_background,
 .notion-gray_background {
   padding: 0 0.5rem;
-  margin: 0 -0.5rem 0 -0.25rem;
+  margin: 0 -0.25rem 0 -0.25rem;
   border-radius: 0.5rem;
   border-bottom-left-radius: 0.125rem;
   box-decoration-break: clone;
@@ -230,7 +230,7 @@
 
   /* light yellow */
   background-image: linear-gradient(
-    119deg,
+    90deg,
     var(--bg-color),
     #fff697 10.5%,
     #fdf59d 85.29%,
@@ -238,11 +238,21 @@
   );
 }
 
-.notion-purple_background,
+.notion-purple_background {
+  /* light pink */
+  background-image: linear-gradient(
+    90deg,
+    var(--bg-color),
+    #ea418d 10.5%,
+    #f54594 85.29%,
+    var(--bg-color)
+  );
+}
+
 .notion-pink_background {
   /* light pink */
   background-image: linear-gradient(
-    119deg,
+    90deg,
     var(--bg-color),
     #f5b8d1 10.5%,
     #f9bcd3 85.29%,
@@ -250,11 +260,21 @@
   );
 }
 
-.notion-blue_background,
 .notion-gray_background {
   /* light blue */
   background-image: linear-gradient(
-    119deg,
+    90deg,
+    var(--bg-color),
+    #bad1d7 10.5%,
+    #c2dbe1 85.29%,
+    var(--bg-color)
+  );
+}
+
+.notion-blue_background {
+  /* light blue */
+  background-image: linear-gradient(
+    90deg,
     var(--bg-color),
     #adedfc 10.5%,
     #adebfd 85.29%,
@@ -262,14 +282,24 @@
   );
 }
 
-.notion-red_background,
+.notion-red_background {
+  /* light red */
+  background-image: linear-gradient(
+    90deg,
+    var(--bg-color),
+    #f38ea4 10.5%,
+    #fc94ab 85.29%,
+    var(--bg-color)
+  );
+}
+
 .notion-orange_background {
   /* light red */
   background-image: linear-gradient(
-    119deg,
+    90deg,
     var(--bg-color),
-    #f5c4ff 10.5%,
-    #e7a8fc 85.29%,
+    #eaa78a 10.5%,
+    #fcb596 85.29%,
     var(--bg-color)
   );
 }
@@ -277,7 +307,7 @@
 .notion-teal_background {
   /* light green */
   background-image: linear-gradient(
-    119deg,
+    90deg,
     var(--bg-color),
     #d4eabc 10.5%,
     #d2eabc 85.29%,
@@ -288,7 +318,7 @@
 .notion-brown_background {
   /* dark blue */
   background-image: linear-gradient(
-    119deg,
+    90deg,
     var(--bg-color),
     #96b8ec 10.5%,
     #a6c3f0 85.29%,
@@ -308,7 +338,7 @@
   padding: 0;
   margin: 0;
   border-radius: 0;
-  background: none !important;
+  background-image: none !important;
 }
 
 /* if you don't want rounded page icon images, remove this */


### PR DESCRIPTION
https://ambroise-dhenain.vercel.app/about (WIP, started playing with it only yesterday, lots of copycat)

- The margin fix is probably an old typo mistake
- 119 > 90 deg, makes it take less space (left/right), _but might go against what you intended_
- I didn't use Notion's colors for the new colors (purple, grey, red), but they look good enough to me

Before, backgrounds were entirely disabled in dark mode.