### PR TITLE
Removing vertical white bars within landscaping viewing on Safari iOS

### DIFF
--- a/components/PageHead.tsx
+++ b/components/PageHead.tsx
@@ -26,7 +26,13 @@ export const PageHead: React.FC<
       <meta httpEquiv='Content-Type' content='text/html; charset=utf-8' />
       <meta
         name='viewport'
-        content='width=device-width, initial-scale=1, shrink-to-fit=no'
+        content='width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover'
+      />
+
+      <meta name='apple-mobile-web-app-capable' content='yes' />
+      <meta
+        name='apple-mobile-web-app-status-bar-style'
+        content='black-translucent'
       />
 
       <meta name='robots' content='index,follow' />

--- a/components/PageHead.tsx
+++ b/components/PageHead.tsx
@@ -32,7 +32,7 @@ export const PageHead: React.FC<
       <meta name='apple-mobile-web-app-capable' content='yes' />
       <meta
         name='apple-mobile-web-app-status-bar-style'
-        content='black-translucent'
+        content='black'
       />
 
       <meta name='robots' content='index,follow' />


### PR DESCRIPTION
#### Description

Currently the starter has white vertical bars when viewed landscape on Safari on iPhones with a notch.  This change expands the content window to include the notch in Safari when viewed in landscape yet not include the notch when viewed vertically or if installed as a PWA (so the header is not cut off when vertically viewed). 

The additional meta tags, besides the `viewport-fit=cover` are default functionality; however, including them protects the PWA in the case `viewport-fit=cover` becomes no longer supported. If using `transparent-black` the header is cut off so I used `black` though `default` works as well. 

Tested on iPhone 12 Pro Max. 

**Figure 1 - BEFORE:**
![IMG_6394](https://user-images.githubusercontent.com/19499950/173108773-c27cad9c-9c89-4d46-af64-99b644f1e882.PNG)

**Figure 2 - AFTER:**
![IMG_6393](https://user-images.githubusercontent.com/19499950/173108790-74e2ef37-eb94-4909-b391-b59a7f455e83.PNG)


#### Notion Test Page ID

https://alexchaveriat-l3qqg3dvy-si1k.vercel.app/
