### PR TITLE
Adding optional custom logo to header with darkmode support

### DIFF
--- a/components/NotionPageHeader.tsx
+++ b/components/NotionPageHeader.tsx
@@ -62,7 +62,7 @@ export const HeaderLogo: React.FC<{
         </components.PageLink>
       )
     }
-    return props.children
+    return <a style={{ padding: 12 }}>{props.children}</a>
   }
 
   return (

--- a/components/NotionPageHeader.tsx
+++ b/components/NotionPageHeader.tsx
@@ -4,9 +4,17 @@ import { IoSunnyOutline } from '@react-icons/all-files/io5/IoSunnyOutline'
 import { IoMoonSharp } from '@react-icons/all-files/io5/IoMoonSharp'
 import { Header, Breadcrumbs, Search, useNotionContext } from 'react-notion-x'
 import * as types from 'notion-types'
+import Image from 'next/image'
 
 import { useDarkMode } from 'lib/use-dark-mode'
-import { navigationStyle, navigationLinks, isSearchEnabled } from 'lib/config'
+import {
+  navigationStyle,
+  navigationLinks,
+  isSearchEnabled,
+  customHeaderLogo,
+  customHeaderLogoDark,
+  rootNotionPageId
+} from 'lib/config'
 
 import styles from './styles.module.css'
 
@@ -32,6 +40,48 @@ const ToggleThemeButton = () => {
   )
 }
 
+export const HeaderLogo: React.FC<{
+  block: types.CollectionViewPageBlock | types.PageBlock
+}> = ({ block }) => {
+  const { components, mapPageUrl } = useNotionContext()
+
+  const { isDarkMode } = useDarkMode()
+
+  const LinkWrapper = (props: {
+    currentPage: string
+    children: JSX.Element
+  }) => {
+    if (props.currentPage !== '/') {
+      return (
+        <components.PageLink
+          href={mapPageUrl(rootNotionPageId)}
+          key={0}
+          className={cs(styles.navLink, 'breadcrumb', 'button')}
+        >
+          {props.children}
+        </components.PageLink>
+      )
+    }
+    return props.children
+  }
+
+  return (
+    <LinkWrapper currentPage={mapPageUrl(block.id)}>
+      <Image
+        src={
+          isDarkMode && customHeaderLogoDark
+            ? customHeaderLogoDark
+            : customHeaderLogo
+        }
+        width='100%'
+        height='100%'
+        objectFit='contain'
+        alt='logo'
+      />
+    </LinkWrapper>
+  )
+}
+
 export const NotionPageHeader: React.FC<{
   block: types.CollectionViewPageBlock | types.PageBlock
 }> = ({ block }) => {
@@ -44,7 +94,11 @@ export const NotionPageHeader: React.FC<{
   return (
     <header className='notion-header'>
       <div className='notion-nav-header'>
-        <Breadcrumbs block={block} rootOnly={true} />
+        {customHeaderLogo ? (
+          <HeaderLogo block={block} />
+        ) : (
+          <Breadcrumbs block={block} rootOnly={true} />
+        )}
 
         <div className='notion-nav-header-rhs breadcrumbs'>
           {navigationLinks

--- a/components/NotionPageHeader.tsx
+++ b/components/NotionPageHeader.tsx
@@ -62,7 +62,7 @@ export const HeaderLogo: React.FC<{
         </components.PageLink>
       )
     }
-    return <a style={{ padding: 12, display: 'flex' }}>{props.children}</a>
+    return <div style={{ padding: 12, display: 'flex' }}>{props.children}</div>
   }
 
   return (

--- a/components/NotionPageHeader.tsx
+++ b/components/NotionPageHeader.tsx
@@ -62,7 +62,7 @@ export const HeaderLogo: React.FC<{
         </components.PageLink>
       )
     }
-    return <a style={{ padding: 12 }}>{props.children}</a>
+    return <a style={{ padding: 12, display: 'flex' }}>{props.children}</a>
   }
 
   return (

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -61,6 +61,16 @@ export const linkedin: string | null = getSiteConfig('linkedin', null)
 export const newsletter: string | null = getSiteConfig('newsletter', null)
 export const zhihu: string | null = getSiteConfig('zhihu', null)
 
+// default logo values
+export const customHeaderLogo: string | null = getSiteConfig(
+  'customHeaderLogo',
+  null
+)
+export const customHeaderLogoDark: string | null = getSiteConfig(
+  'customHeaderLogoDark',
+  null
+)
+
 // default notion values for site-wide consistency (optional; may be overridden on a per-page basis)
 export const defaultPageIcon: string | null = getSiteConfig(
   'defaultPageIcon',

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -17,6 +17,9 @@ export interface SiteConfig {
   youtube?: string
   zhihu?: string
 
+  customHeaderLogo?: string | null
+  customHeaderLogoDark?: string | null
+
   defaultPageIcon?: string | null
   defaultPageCover?: string | null
   defaultPageCoverPosition?: number | null

--- a/site.config.ts
+++ b/site.config.ts
@@ -23,7 +23,7 @@ export default siteConfig({
   // newsletter: '#', // optional newsletter URL
   // youtube: '#', // optional youtube channel name or `channel/UCGbXXXXXXXXXXXXXXXXXXXXXX`
 
-  // Custom logo - this will replace the breadcrumbs
+  // Custom logo - this will replace the breadcrumbs - Feature requires navigationStyle: 'custom'
   // customHeaderLogo: 'https://transitivebullsh.it/logo.png',
   // customHeaderLogoDark: 'https://transitivebullsh.it/logo-dark.png', // optional
 

--- a/site.config.ts
+++ b/site.config.ts
@@ -23,6 +23,10 @@ export default siteConfig({
   // newsletter: '#', // optional newsletter URL
   // youtube: '#', // optional youtube channel name or `channel/UCGbXXXXXXXXXXXXXXXXXXXXXX`
 
+  // Custom logo - this will replace the breadcrumbs
+  // customHeaderLogo: 'https://cdn.logo.com/hotlink-ok/logo-social.png',
+  // customHeaderLogoDark: 'https://alexchaveriat-com.vercel.app/logo-dark.png',
+
   // default notion icon and cover images for site-wide consistency (optional)
   // page-specific values will override these site-wide defaults
   defaultPageIcon: null,

--- a/site.config.ts
+++ b/site.config.ts
@@ -24,8 +24,8 @@ export default siteConfig({
   // youtube: '#', // optional youtube channel name or `channel/UCGbXXXXXXXXXXXXXXXXXXXXXX`
 
   // Custom logo - this will replace the breadcrumbs
-  // customHeaderLogo: 'https://cdn.logo.com/hotlink-ok/logo-social.png',
-  // customHeaderLogoDark: 'https://alexchaveriat-com.vercel.app/logo-dark.png',
+  // customHeaderLogo: 'https://transitivebullsh.it/logo.png',
+  // customHeaderLogoDark: 'https://transitivebullsh.it/logo-dark.png', // optional
 
   // default notion icon and cover images for site-wide consistency (optional)
   // page-specific values will override these site-wide defaults


### PR DESCRIPTION
#### Description

Added the ability to add a logo to the top header. This feature is optional. It also supports using just one logo/image or having different ones for both light and dark mode. 

On non-root pages the logo will link to the home page and on the root page the logo is shown without a link. I added `padding` to ensure the logo does not shift when switching between pages and root. 

Note: It does require `navigationStyle: 'custom'` - last commit added this to the `site.config.ts` comments.

<img width="1208" alt="image" src="https://user-images.githubusercontent.com/19499950/173191455-a9179ffa-bc33-43ec-8724-e5ca83728813.png">

<img width="1213" alt="image" src="https://user-images.githubusercontent.com/19499950/173191469-b867607c-5dd8-4544-8a9a-99858d4c2c6a.png">


#### Notion Test Page ID

I have it implemented on my page - https://alexchaveriat.com/
