### PR TITLE
feat: add type safety for getStaticProps

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,5 @@
 import { ExtendedRecordMap, PageMap } from 'notion-types'
+import { ParsedUrlQuery } from 'querystring'
 
 export * from 'notion-types'
 
@@ -14,6 +15,10 @@ export interface PageProps {
   recordMap?: ExtendedRecordMap
   pageId?: string
   error?: PageError
+}
+
+export interface Params extends ParsedUrlQuery {
+  pageId: string
 }
 
 export interface Site {

--- a/pages/[pageId].tsx
+++ b/pages/[pageId].tsx
@@ -1,10 +1,12 @@
 import * as React from 'react'
+import { GetStaticProps } from 'next'
 import { isDev, domain } from 'lib/config'
 import { getSiteMap } from 'lib/get-site-map'
 import { resolveNotionPage } from 'lib/resolve-notion-page'
+import { PageProps, Params } from 'lib/types'
 import { NotionPage } from 'components'
 
-export const getStaticProps = async (context) => {
+export const getStaticProps: GetStaticProps<PageProps, Params> = async (context) => {
   const rawPageId = context.params.pageId as string
 
   try {


### PR DESCRIPTION
#### Description

`getStaticProps` is a very critical function in building stuffs with Notion, so I want to ensure type safety for it. What I did:

First, I use the `GetStaticProps` type provided out of the box by Next.js.

```
import { GetStaticProps } from 'next'

export const getStaticProps: GetStaticProps = async (context) => {
  //...
}
```

This means that `getStaticProps` the function has to return an object with a `props` property.

However, there is a potential for improvement. The whole workflow in `[pageId].tsx` relies on `pageId` param. If you pass `{params: {slug: ''}}` instead of `{params: {pageId: ""}}` to `getStaticProps`, Typescript won't complain.

So I add a new interface `Params` and also make sure that the `props` property in the returned value of `getStaticProps`  takes the value of `PageProps` already defined in `lib/types.ts`.

```
export const getStaticProps: GetStaticProps<PageProps, Params> = async (context) => {
}
```

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID

`cc368b47772a4a1aa36e1f52c507d20d`

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
