### PR TITLE
feat: optimize search keywords color

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -363,6 +363,10 @@
   backdrop-filter: saturate(180%) blur(8px);
 }
 
+.dark-mode .notion-search .searchBar .searchInput {
+  color: var(--fg-color);
+}
+
 /* Workaround for Firefox not supporting backdrop-filter yet */
 @-moz-document url-prefix() {
   .dark-mode .notion-header {


### PR DESCRIPTION
#### Description
Maybe I think the serachBar keywords'color should alter,the user of this repository can find it more easily in dark mode !
![image](https://user-images.githubusercontent.com/52097543/177776374-ad84b619-56b8-40ff-ad81-d75734b78f7c.png)
![image](https://user-images.githubusercontent.com/52097543/177776602-59b62227-bff9-4adb-8034-0d4f61731ed6.png)


#### Notion Test Page ID

you can reproduct it on your site [transitivebullsh.it/nextjs-notion-starter-kit](https://transitivebullsh.it/nextjs-notion-starter-kit)
