### PR TITLE
fix: need Node.js 14.x since chrome-aws-lambda only supports that version.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 14
           cache: yarn
 
       - run: yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "repository": "transitive-bullshit/nextjs-notion-starter-kit",
   "license": "MIT",
   "engines": {
-    "node": ">=14.17"
+    "node": "^14.17"
   },
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "author": "Travis Fischer <travis@transitivebullsh.it>",
   "repository": "transitive-bullshit/nextjs-notion-starter-kit",
   "license": "MIT",
-  "engines": {
-    "node": "^14.17"
-  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
This commit fix the failure execution of api/social-image.
The problem is cause by incompatible node version. (currently in 16, but
only 14 is support by chrome-aws-lambda).

Filed social-image-api in demo: **https://nextjs-notion-starter-kit.transitivebullsh.it/api/social-image?id=27aaa1b5-03fb-44e9-a0d8-42a9e8f39325**

Related issue: https://github.com/alixaxel/chrome-aws-lambda/issues/275