### PR TITLE
fix: dark mode color when loading page

### DIFF
--- a/components/styles.module.css
+++ b/components/styles.module.css
@@ -21,6 +21,7 @@
   caret-color: rgb(55, 53, 47);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica,
     'Apple Color Emoji', Arial, sans-serif, 'Segoe UI Emoji', 'Segoe UI Symbol';
+  background-color: var(--bg-color);
 }
 
 .loadingIcon {


### PR DESCRIPTION
#### Description

For some reason, when it takes a little longer to load a page, the Loading screen loads without the dark-theme color background.

So this simple line solved this problem

#### Notion Test Page ID

b569ac4fbbe84ef5bddea75d87f81594
