### PR TITLE
fix: dark mode for searchInput

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -33,3 +33,8 @@ body {
   height: 1.2em !important;
   width: 1.2em !important;
 }
+
+.searchInput {
+  color: var(--fg-color);
+  caret-color: var(--fg-color);
+}


### PR DESCRIPTION
#### Description

Inside the Search bar, the text is black in dark-mode, which is really hard to read
![image](https://user-images.githubusercontent.com/50552672/193456202-f1a9f3ed-1f15-46a7-ae7e-e34d0994d8b7.png)


#### Notion Test Page ID

998819aed701425895bf919ed02898a7

