### PR TITLE
✨ Add support for Mastodon link in footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { FaEnvelopeOpenText } from '@react-icons/all-files/fa/FaEnvelopeOpenText'
 import { FaGithub } from '@react-icons/all-files/fa/FaGithub'
 import { FaLinkedin } from '@react-icons/all-files/fa/FaLinkedin'
+import { FaMastodon } from '@react-icons/all-files/fa/FaMastodon'
 import { FaTwitter } from '@react-icons/all-files/fa/FaTwitter'
 import { FaYoutube } from '@react-icons/all-files/fa/FaYoutube'
 import { FaZhihu } from '@react-icons/all-files/fa/FaZhihu'
@@ -60,6 +61,17 @@ export const FooterImpl: React.FC = () => {
             rel='noopener noreferrer'
           >
             <FaTwitter />
+          </a>
+        )}
+
+        {config.mastodon && (
+          <a
+            className={styles.mastodon}
+            href={config.mastodon}
+            title={`Mastodon ${config.getMastodonHandle()}`}
+            rel='me'
+          >
+            <FaMastodon />
           </a>
         )}
 

--- a/components/styles.module.css
+++ b/components/styles.module.css
@@ -93,6 +93,10 @@
   color: #2795e9;
 }
 
+.mastodon:hover {
+  color: #5a4be1;
+}
+
 .zhihu:hover {
   color: #0066ff;
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -55,11 +55,23 @@ export const language: string = getSiteConfig('language', 'en')
 
 // social accounts
 export const twitter: string | null = getSiteConfig('twitter', null)
+export const mastodon: string | null = getSiteConfig('mastodon', null)
 export const github: string | null = getSiteConfig('github', null)
 export const youtube: string | null = getSiteConfig('youtube', null)
 export const linkedin: string | null = getSiteConfig('linkedin', null)
 export const newsletter: string | null = getSiteConfig('newsletter', null)
 export const zhihu: string | null = getSiteConfig('zhihu', null)
+
+export const getMastodonHandle = (): string | null => {
+  if (!mastodon) {
+    return null
+  }
+
+  // Since Mastodon is decentralized, handles include the instance domain name.
+  // e.g. @example@mastodon.social
+  const url = new URL(mastodon)
+  return `${url.pathname.slice(1)}@${url.hostname}`
+}
 
 // default notion values for site-wide consistency (optional; may be overridden on a per-page basis)
 export const defaultPageIcon: string | null = getSiteConfig(

--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -16,6 +16,7 @@ export interface SiteConfig {
   newsletter?: string
   youtube?: string
   zhihu?: string
+  mastodon?: string;
 
   defaultPageIcon?: string | null
   defaultPageCover?: string | null

--- a/site.config.ts
+++ b/site.config.ts
@@ -20,6 +20,7 @@ export default siteConfig({
   twitter: 'transitive_bs',
   github: 'transitive-bullshit',
   linkedin: 'fisch2',
+  // mastodon: '#', // optional mastodon profile URL, provides link verification
   // newsletter: '#', // optional newsletter URL
   // youtube: '#', // optional youtube channel name or `channel/UCGbXXXXXXXXXXXXXXXXXXXXXX`
 


### PR DESCRIPTION
#### Description

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

Add a Mastodon profile link to the footer if config.mastdon is set to a mastodon profile URL.

![Screenshot 2022-11-12 at 11 26 50 PM](https://user-images.githubusercontent.com/1653961/201514274-08c4653a-c69b-489e-92d5-21b03b7d34c7.png)
_see mastodon icon in bottom right_

The hover state is the [new vibrant purple](https://blog.joinmastodon.org/2022/06/mastodon-branding-updates/).

#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->

I don't think a notion page id is helpful here, but you can see my Mastodon link on the footer of https://overacker.me.
