### PR TITLE
Fix p-queue new version bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   "overrides": {
     "cacheable-request": {
       "keyv": "npm:@keyvhq/core@~1.6.6"
-    }
+    },
+    "p-queue": "7.3.0"
   }
 }


### PR DESCRIPTION
The new version of p-queue causes "Module not found: Can't resolve 'p-queue'" error

#### Description

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
