### PR TITLE
Make header scrollable

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -42,6 +42,7 @@
 .notion-header .notion-nav-header {
   max-width: 1100px;
   margin: 0 auto;
+  overflow-x: auto;
 }
 
 .notion-nav-header-rhs {


### PR DESCRIPTION
#### Description

Longer page titles text to overflow off the right side of the screen. This small change will enable users to scroll the header horizontally on mobile devices so they can read the whole page title

#### Notion Test Page ID

bc00abc7d4d14af5baf9eab5d89af140
