### PR TITLE
Support RTL mode switching from site.config

### DIFF
--- a/lib/site-config.ts
+++ b/lib/site-config.ts
@@ -16,11 +16,13 @@ export interface SiteConfig {
   newsletter?: string
   youtube?: string
   zhihu?: string
-  mastodon?: string;
+  mastodon?: string
 
   defaultPageIcon?: string | null
   defaultPageCover?: string | null
   defaultPageCoverPosition?: number | null
+
+  RTL: boolean
 
   isPreviewImageSupportEnabled?: boolean
   isTweetEmbedSupportEnabled?: boolean

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import Document, { Head, Html, Main, NextScript } from 'next/document'
 
 import { IconContext } from '@react-icons/all-files'
+import siteConfig from 'site.config'
 
 export default class MyDocument extends Document {
   render() {
@@ -20,7 +21,7 @@ export default class MyDocument extends Document {
             <link rel='manifest' href='/manifest.json' />
           </Head>
 
-          <body>
+          <body dir={siteConfig.RTL ? 'rtl' : 'ltr'}>
             <script
               dangerouslySetInnerHTML={{
                 __html: `

--- a/site.config.ts
+++ b/site.config.ts
@@ -30,6 +30,9 @@ export default siteConfig({
   defaultPageCover: null,
   defaultPageCoverPosition: 0.5,
 
+  // if you want to switch the display direction to right-to-left  (e.g. in case you have Arabic content)
+  RTL: false,
+
   // whether or not to enable support for LQIP preview images (optional)
   isPreviewImageSupportEnabled: true,
 


### PR DESCRIPTION
#### Description

I added a new entry to the `site.config` to enable RTL mode just by set it to true. It works fine for Arabic content.

#### Notion Test Page ID
This is a preview deployment for this change: https://next-notion-starter-kit-ar.vercel.app/
And this is the 

