### PR TITLE
fix: remove the transparent line above the header

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -12,6 +12,10 @@
   --notion-header-height: 54px;
 }
 
+.notion-frame {
+  padding: 0;
+}
+
 .notion-page {
   padding-bottom: calc(max(5vh, 32px)) !important;
   line-height: 1.65;


### PR DESCRIPTION
#### Description

There is a transparent line above the header which height is just 1px, its get my OCD's mind crazy, this commit is to remove it.

![image](https://user-images.githubusercontent.com/46417244/224540306-b42e944d-f40a-4205-a863-edf34cfa5a30.png)

![image](https://user-images.githubusercontent.com/46417244/224540321-4615db4d-cc6d-43b6-95cf-88e7ed3a1fef.png)


#### Notion Test Page ID

The personal blog in the readme has this problem too.

https://transitivebullsh.it/
