### PR TITLE
feature: optimize header's backdrop-filter in dark mode

### DIFF
--- a/components/PageHead.tsx
+++ b/components/PageHead.tsx
@@ -28,6 +28,9 @@ export const PageHead: React.FC<
         name='viewport'
         content='width=device-width, initial-scale=1, shrink-to-fit=no'
       />
+      
+      <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fefffe" key="theme-color-light"/>
+      <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#2d3439" key="theme-color-dark"/>
 
       <meta name='robots' content='index,follow' />
       <meta property='og:type' content='website' />

--- a/styles/notion.css
+++ b/styles/notion.css
@@ -360,7 +360,7 @@
 .dark-mode .notion-header {
   background: transparent;
   box-shadow: inset 0 -1px 0 0 rgba(0, 0, 0, 0.1);
-  backdrop-filter: saturate(180%) blur(8px);
+  backdrop-filter: saturate(180%) blur(20px);
 }
 
 /* Workaround for Firefox not supporting backdrop-filter yet */


### PR DESCRIPTION
#### Description

optimize header's backdrop-filter in dark mode, make it more blur to reduce distraction by the header.

here is the difference:
before:
![image](https://user-images.githubusercontent.com/46417244/224550907-7612e01f-2573-4453-8e2a-4aa14ab0ae29.png)

optimized:

![image](https://user-images.githubusercontent.com/46417244/224550924-829134b8-e53a-4022-a331-2c88952e4c8f.png)


