### PR TITLE
feature: optimize header's backdrop-filter in dark mode.

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -364,7 +364,7 @@
 .dark-mode .notion-header {
   background: transparent;
   box-shadow: inset 0 -1px 0 0 rgba(0, 0, 0, 0.1);
-  backdrop-filter: saturate(180%) blur(8px);
+  backdrop-filter: saturate(180%) blur(20px);
 }
 
 /* Workaround for Firefox not supporting backdrop-filter yet */


### PR DESCRIPTION
#### Description

optimize header's backdrop-filter in dark mode, make it more blur to reduce distraction by the header.

here is the difference:

before:
![image](https://user-images.githubusercontent.com/46417244/224552651-5c53cd4f-586b-49bc-81df-95d31181b5d6.png)

optimized:
![image](https://user-images.githubusercontent.com/46417244/224552651-5c53cd4f-586b-49bc-81df-95d31181b5d6.png)
