### PR TITLE
feature: optimize header's backdrop-filter in dark mode.

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -364,7 +364,7 @@
 .dark-mode .notion-header {
   background: transparent;
   box-shadow: inset 0 -1px 0 0 rgba(0, 0, 0, 0.1);
-  backdrop-filter: saturate(180%) blur(8px);
+  backdrop-filter: saturate(180%) blur(20px);
 }
 
 /* Workaround for Firefox not supporting backdrop-filter yet */


### PR DESCRIPTION
optimize header's backdrop-filter in dark mode, make it more blur to reduce distraction by the header.

here is the difference:

before:
![image](https://user-images.githubusercontent.com/46417244/224552857-ccc2c3d2-4bc0-41ef-b869-17dc2a412f03.png)

optimized:
![image](https://user-images.githubusercontent.com/46417244/224552884-02ae8b8c-3963-4731-a941-735ab96dcef6.png)
