### PR TITLE
feature: set color for mobile browser status bar

### DIFF
--- a/components/PageHead.tsx
+++ b/components/PageHead.tsx
@@ -29,6 +29,9 @@ export const PageHead: React.FC<
         content='width=device-width, initial-scale=1, shrink-to-fit=no'
       />
 
+      <meta name="theme-color" media="(prefers-color-scheme: light)" content="#fefffe" key="theme-color-light"/>
+      <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#2d3439" key="theme-color-dark"/>
+
       <meta name='robots' content='index,follow' />
       <meta property='og:type' content='website' />
 


### PR DESCRIPTION


#### Description

Set color for mobile browser status bar, it'll diffirent due to the dark or light mode of mobile devices.

here is the difference:

before:
![image](https://user-images.githubusercontent.com/46417244/224554510-04479ee6-1702-45e2-a73d-d9d583f021dd.png)


optimized:
light mode:
![image](https://user-images.githubusercontent.com/46417244/224554537-2be7813a-bcb9-4db5-bb69-5b7023d2b18e.png)

dark mode:
![image](https://user-images.githubusercontent.com/46417244/224554552-b2f31333-a0da-490c-b5ea-4bd130da182a.png)

