### PR TITLE
feature: Update copyright year automatically

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -20,6 +20,7 @@ import styles from './styles.module.css'
 export const FooterImpl: React.FC = () => {
   const [hasMounted, setHasMounted] = React.useState(false)
   const { isDarkMode, toggleDarkMode } = useDarkMode()
+  const currentYear = new Date().getFullYear()
 
   const onToggleDarkMode = React.useCallback(
     (e) => {
@@ -35,7 +36,7 @@ export const FooterImpl: React.FC = () => {
 
   return (
     <footer className={styles.footer}>
-      <div className={styles.copyright}>Copyright 2022 {config.author}</div>
+      <div className={styles.copyright}>Copyright { currentYear } {config.author}</div>
 
       <div className={styles.settings}>
         {hasMounted && (


### PR DESCRIPTION
#### Description

The copyright on the website is out of date.
It would be helpful to have an automatic way to update the copyright year.

**before**
<img width="1919" alt="image" src="https://user-images.githubusercontent.com/25585061/226248713-d01e6511-a897-42ea-b6cb-043fd0e71f44.png">

**after**
<img width="1917" alt="image" src="https://user-images.githubusercontent.com/25585061/226248545-3046b730-51d7-47db-adbf-d0932c37489a.png">

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->
