### PR TITLE
fix search dialog in dark mode

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -386,3 +386,15 @@
 .notion-block-260baa77f1e1428b97fb14ac99c7c385 {
   display: none;
 }
+
+.notion-search .searchBar {
+  box-shadow: var(--fg-color-0) 0px 1px 0px;
+}
+
+.notion-search .noResults {
+  color: var(--fg-color-3);
+}
+
+.notion-search .noResultsDetail {
+  color: var(--fg-color-2);
+}


### PR DESCRIPTION
#### Description
SearchDialog noResults text color is not correct in dark mode.

Now:
<img width="612" alt="截屏2023-03-31 14 48 42" src="https://user-images.githubusercontent.com/49476516/229044615-437f9957-2e0c-4cf1-8e81-987b86fa2a54.png">

Fixed:
<img width="612" alt="截屏2023-03-31 14 48 42" src="https://user-images.githubusercontent.com/49476516/229046048-0839fa0d-c0da-4c7b-829b-849a3832bc75.png">

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID
7875426197cf461698809def95960ebf
<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->
