### PR TITLE
Fix the problem of wrong display of home page image in safari browser.

### DIFF
--- a/styles/notion.css
+++ b/styles/notion.css
@@ -100,6 +100,10 @@
   filter: none;
 }
 
+.notion-collection-card-cover span{
+  display: block !important;
+}
+
 .notion-collection-card:hover .notion-collection-card-cover {
   filter: brightness(120%);
 }


### PR DESCRIPTION
#### Description

environment:
  macOS Ventura 13.3 safari browser

Image display style error, using edge and chrome view no problem.

![Xnip2023-04-03_17-15-35](https://user-images.githubusercontent.com/21971650/229466467-398e331f-4b15-445e-9223-f41d4ea203c0.jpg)

#### Notion Test Page ID

Any.

7875426197cf461698809def95960ebf
