### PR TITLE
fix: Problem that Code block is not displayed if even one import fails.

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -35,7 +35,7 @@ import styles from './styles.module.css'
 const Code = dynamic(() =>
   import('react-notion-x/build/third-party/code').then(async (m) => {
     // add / remove any prism syntaxes here
-    await Promise.all([
+    await Promise.allSettled([
       import('prismjs/components/prism-markup-templating.js'),
       import('prismjs/components/prism-markup.js'),
       import('prismjs/components/prism-bash.js'),


### PR DESCRIPTION
#### Description

Promise.all() in Code block fails if even one import process fails, resulting in https://github.com/transitive-bullshit/nextjs-notion-starter-kit/issues/477 The problem occurs.

By using Promise.allSettled(), the Code block will be displayed even if it partially fails.

#### Notion Test Page ID

https://transitive-bs.notion.site/Code-Blocks-0c322c33381c49bca5083a451c334c39