### PR TITLE
Simplify copyright and add 'All rights reserved' text

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -36,7 +36,7 @@ export const FooterImpl: React.FC = () => {
 
   return (
     <footer className={styles.footer}>
-      <div className={styles.copyright}>Copyright {currentYear} {config.author}</div>
+      <div className={styles.copyright}>© Copyright {currentYear}. All rights reserved.</div>
 
       <div className={styles.settings}>
         {hasMounted && (


### PR DESCRIPTION
#### Description

This way the copyright notice should work according to normal industry best practices.

Usually larger entities don't even add the person or company name so I also removed it to make it shorter.

#### Notion Test Page ID
It should work with the default one: 7875426197cf461698809def95960ebf
