### PR TITLE
Remove duplicate twitter meta properties which fallback to Opengraph

### DIFF
--- a/components/PageHead.tsx
+++ b/components/PageHead.tsx
@@ -56,14 +56,12 @@ export const PageHead: React.FC<
         <>
           <meta name='description' content={description} />
           <meta property='og:description' content={description} />
-          <meta name='twitter:description' content={description} />
         </>
       )}
 
       {socialImageUrl ? (
         <>
           <meta name='twitter:card' content='summary_large_image' />
-          <meta name='twitter:image' content={socialImageUrl} />
           <meta property='og:image' content={socialImageUrl} />
         </>
       ) : (
@@ -74,7 +72,6 @@ export const PageHead: React.FC<
         <>
           <link rel='canonical' href={url} />
           <meta property='og:url' content={url} />
-          <meta property='twitter:url' content={url} />
         </>
       )}
 
@@ -86,7 +83,6 @@ export const PageHead: React.FC<
       />
 
       <meta property='og:title' content={title} />
-      <meta name='twitter:title' content={title} />
       <title>{title}</title>
     </Head>
   )


### PR DESCRIPTION
#### Description
Removing unnecessary twitter meta properties which can fallback to the corresponding Opengraph `og` meta properties.

See example from Twitter docs here: https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started

And also from: https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup

#### Notion Test Page ID
7875426197cf461698809def95960ebf (this is the default page id in the project readme)