### PR TITLE
Bug: Fix syntax highlighting issues for C++ and F#

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -242,6 +242,19 @@ export const NotionPage: React.FC<types.PageProps> = ({
     getPageProperty<string>('Description', block, recordMap) ||
     config.description
 
+  try {
+    Object.keys(recordMap.block).forEach((key) => {
+      try {
+        if (recordMap.block[key].value.properties.language[0][0] === 'C++') {
+          recordMap.block[key].value.properties.language[0][0] = 'Cpp'
+        }
+        else if (recordMap.block[key].value.properties.language[0][0] === 'F#') {
+          recordMap.block[key].value.properties.language[0][0] = 'Fsharp'
+        }
+      } catch (_){}
+    })
+  } catch (_) {}
+
   return (
     <>
       <PageHead


### PR DESCRIPTION
#### Description

Please refer to #309 for details.

Edit is suggested by @amogh-w and @zhufengning.

Another issue https://github.com/NotionX/react-notion-x/issues/220 also spots the same issue, however after the fix C++ code block still has no syntax highlighting.

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

#### Notion Test Page ID

[https://powerium.notion.site/powerium-io-140a3ff49ba9416c8e8fc7584b8bee56](https://powerium.notion.site/powerium-io-140a3ff49ba9416c8e8fc7584b8bee56?pvs=4)
