### PR TITLE
SEO improvements: Add json+ld schema.org microdata for Blog Posts

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -250,6 +250,7 @@ export function NotionPage({
         description={socialDescription}
         image={socialImage}
         url={canonicalPageUrl}
+        isBlogPost={isBlogPost}
       />
 
       {isLiteMode && <BodyClassName className='notion-lite' />}

--- a/components/PageHead.tsx
+++ b/components/PageHead.tsx
@@ -10,12 +10,14 @@ export function PageHead({
   description,
   pageId,
   image,
-  url
+  url,
+  isBlogPost
 }: types.PageProps & {
   title?: string
   description?: string
   image?: string
   url?: string
+  isBlogPost?: boolean
 }) {
   const rssFeedUrl = `${config.host}/feed`
 
@@ -99,6 +101,41 @@ export function PageHead({
       <meta property='og:title' content={title} />
       <meta name='twitter:title' content={title} />
       <title>{title}</title>
+
+      { /* Better SEO for the blog posts */ }
+      { isBlogPost && (
+        // See more here: https://schema.org/BlogPosting
+        <script type="application/ld+json">
+          {JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            "@id": `${url}#BlogPosting`,
+            "mainEntityOfPage": url,
+            url,
+            "headline": title,
+            "name": title,
+            description,
+            "author": {
+              "@type": "Person",
+              // TODO: Google Rich Search results recommends adding the url:
+              // "url": "..."
+              "name": config.author,
+            },
+            "image": socialImageUrl,
+            // TODO: Figure out how to pull these from the Notion content
+            //"datePublished": "2024-11-08",
+            //"dateModified": "2024-11-08",
+            //"wordCount": "488",
+            //"keywords": [
+            //    "tags",
+            //    "should",
+            //    "be"
+            //    "here"
+            //],
+            //"articleBody": "..."
+          })}
+        </script>
+      )}
     </Head>
   )
 }


### PR DESCRIPTION
#### Description

Initial steps on improving SEO for the blog posts. This adds https://schema.org/BlogPosting type microdata to the website which is one way to help Google/Bing to understand what the content is about.

@transitive-bullshit if you can show me how to get the publish dates and edited dates from the content that would be great 👌

We can also move this into the body if accessing these are easier there.

#### Notion Test Page ID

7875426197cf461698809def95960ebf

