### PR TITLE
Fix apple-mobile-web-app-capable deprecated meta tag deprecated warning

### DIFF
--- a/components/PageHead.tsx
+++ b/components/PageHead.tsx
@@ -33,7 +33,7 @@ export function PageHead({
         content='width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover'
       />
 
-      <meta name='apple-mobile-web-app-capable' content='yes' />
+      <meta name='mobile-web-app-capable' content='yes' />
       <meta name='apple-mobile-web-app-status-bar-style' content='black' />
 
       <meta


### PR DESCRIPTION
#### Description

I noticed following issue from Chrome console:

```html
<meta name="apple-mobile-web-app-capable" content="yes"> is deprecated. Please include <meta name="mobile-web-app-capable" content="yes">
```

This should fix it.
