### PR TITLE
Notion id on env

### DIFF
--- a/site.config.ts
+++ b/site.config.ts
@@ -2,7 +2,7 @@ import { siteConfig } from './lib/site-config'
 
 export default siteConfig({
   // the site's root Notion page (required)
-  rootNotionPageId: '7875426197cf461698809def95960ebf',
+  rootNotionPageId: process.env.NOTION_PAGE_ID ?? 'MISSING_ID',
 
   // if you want to restrict pages to a single notion workspace (optional)
   // (this should be a Notion ID; see the docs for how to extract this)


### PR DESCRIPTION
Switched from hardcoded Notion page ID to dynamic environment variable. 
This allows the deployed site to use the correct `NOTION_PAGE_ID` set in Vercel.
9f62e4c998c84eb884a22b5a85fe3b5b

