### PR TITLE
fix: resolve ReferenceError for undefined isBlogPost in PageHead component

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -297,6 +297,7 @@ export function NotionPage({
         description={socialDescription}
         image={socialImage}
         url={canonicalPageUrl}
+        isBlogPost={isBlogPost}
       />
 
       {isLiteMode && <BodyClassName className='notion-lite' />}

--- a/components/PageHead.tsx
+++ b/components/PageHead.tsx
@@ -10,12 +10,14 @@ export function PageHead({
   description,
   pageId,
   image,
-  url
+  url,
+  isBlogPost
 }: types.PageProps & {
   title?: string
   description?: string
   image?: string
   url?: string
+  isBlogPost?: boolean
 }) {
   const rssFeedUrl = `${config.host}/feed`
 


### PR DESCRIPTION
### 🐛 Problem
The application was throwing a `ReferenceError: isBlogPost is not defined` runtime error in the `PageHead`
component at line 104.  The error occurred because the `isBlogPost` variable was being used in the JSX template but was not defined in the component's scope.

### 🔧 Solution

- Added `isBlogPost` as an optional boolean prop to the `PageHead` component interface

- Updated the `NotionPage` component to pass the existing isBlogPost variable to the `PageHead` component

- The `isBlogPost` logic was already correctly implemented in `NotionPage` but wasn't being passed down as a prop

### 📝 Changes Made

1. components/PageHead.tsx:

- Added `isBlogPost?: boolean`  to the component props interface

- Added `isBlogPost` parameter to the function signature

2. components/NotionPage.tsx:

- Added `isBlogPost={isBlogPost}` prop to the `PageHead` component call

### ✅ Testing

- Verified the runtime error is resolved

- Confirmed blog post structured data is properly rendered when isBlogPost is true

- No breaking changes to existing functionality

### 🎯 Impact

This fix ensures that blog posts will have proper SEO structured data (JSON-LD) included in the page head, improving search engine optimization for blog content.

---------------------------------------------------------------------------------------------------------------------

Type: Bug Fix
Breaking Change: No
Closes: #[issue-number] (if applicable)