### PR TITLE
fix: Include pageUrlOverrides in getStaticPaths

### DIFF
--- a/pages/[pageId].tsx
+++ b/pages/[pageId].tsx
@@ -1,7 +1,7 @@
 import { type GetStaticProps } from 'next'
 
 import { NotionPage } from '@/components/NotionPage'
-import { domain, isDev } from '@/lib/config'
+import { domain, isDev, pageUrlOverrides } from '@/lib/config'
 import { getSiteMap } from '@/lib/get-site-map'
 import { resolveNotionPage } from '@/lib/resolve-notion-page'
 import { type PageProps, type Params } from '@/lib/types'
@@ -34,13 +34,17 @@ export async function getStaticPaths() {
 
   const siteMap = await getSiteMap()
 
+  // Combine sitemap paths with URL overrides (e.g., /articles, /notes)
+  // URL overrides might not be in the sitemap if not directly linked from root
+  const allPageIds = [
+    ...new Set([
+      ...Object.keys(siteMap.canonicalPageMap),
+      ...Object.keys(pageUrlOverrides)
+    ])  
+  ]
+
   const staticPaths = {
-    paths: Object.keys(siteMap.canonicalPageMap).map((pageId) => ({
-      params: {
-        pageId
-      }
-    })),
-    // paths: [],
+    paths: allPageIds.map((pageId) => ({ params: { pageId } })),
     fallback: true
   }
 


### PR DESCRIPTION
URL override paths (e.g., /articles, /notes) may not be in the sitemap if they're not directly linked from the root Notion page. This ensures they are pre-rendered at build time, fixing 404s in production.

#### Description

<!--
Please include as detailed of a description as possible, including screenshots if applicable.
-->

Let's say you have sitemap:

```
pageUrlOverrides: {
  '/articles': 'e40efc6731ea4e1da2626d709950fbe4',
  ...
}
```

Unless `e40efc6731ea4e1da2626d709950fbe4` is within the tree of the root Notion page, it doesn't get loaded properly (in prod, works fine on local)

#### Notion Test Page ID

<!--
Please include the ID of at least one publicly accessible Notion page related to your PR.

This is extremely helpful for us to debug and fix issues.

Thanks!
-->

Tested on personal website: https://wustep.me/articles
(https://github.com/wustep/me)