### PR TITLE
fix: hide embedded database title when Notion show data source titles…

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -202,7 +202,43 @@ export function NotionPage({
       nextLegacyImage: Image,
       nextLink: Link,
       Code,
-      Collection,
+      Collection: (props: any) => {
+        if (props.block?.type === 'collection_view') {
+          const viewIds = props.block.view_ids
+          if (viewIds && viewIds.length > 0) {
+            // When Notion's "show data source titles" is OFF, Notion sets
+            // hide_inline_collection_name: true on the block's format.
+            // react-notion-x reads this as hide_linked_collection_name on the
+            // collectionView format, so we propagate it to all views.
+            const shouldHideTitle =
+              props.block.format?.hide_inline_collection_name === true
+
+            viewIds.forEach((viewId: string) => {
+              const view = recordMap?.collection_view?.[viewId]?.value as any
+              if (!view) return
+
+              if (shouldHideTitle) {
+                view.format = view.format || {}
+                view.format.hide_linked_collection_name = true
+              }
+
+              // Notion api does not fetch child blocks for page_content gallery images.
+              // If the gallery_cover is set to page_content or page_content_first, we override it to page_cover.
+              if (
+                view?.format?.gallery_cover?.type === 'page_content' ||
+                view?.format?.gallery_cover?.type === 'page_content_first' ||
+                view?.format?.gallery_cover?.type === 'none' ||
+                view?.format?.gallery_cover === undefined
+              ) {
+                if (view && view.format) {
+                  view.format.gallery_cover = { type: 'page_cover' }
+                }
+              }
+            })
+          }
+        }
+        return <Collection {...props} />
+      },
       Equation,
       Pdf,
       Modal,
@@ -284,8 +320,8 @@ export function NotionPage({
 
   const socialImage = mapImageUrl(
     getPageProperty<string>('Social Image', block, recordMap) ||
-      (block as PageBlock).format?.page_cover ||
-      config.defaultPageCover,
+    (block as PageBlock).format?.page_cover ||
+    config.defaultPageCover,
     block
   )
 


### PR DESCRIPTION
## Description

#### Problem
Currently, when a database is embedded on a Notion page and **"Show data source titles"** is toggled off, Notion sets `hide_inline_collection_name: true` on the `block.format` object. 

However, `react-notion-x` reads `hide_linked_collection_name` from the `collectionView.format` (a different field/object), causing the database title to always be displayed regardless of the user's setting in Notion.

#### Solution
This fix propagates the flag from `block.format.hide_inline_collection_name` to `collectionView.format.hide_linked_collection_name`. This ensures that `react-notion-x`'s `showTitle` check correctly recognizes the intent to hide the database title.

#### Changes
- Mapped `block.format.hide_inline_collection_name` to `collectionView.format.hide_linked_collection_name` during the data transformation process.
- Fixed the UI discrepancy where hidden titles in Notion were still rendered in the web view.

---

#### Screenshots
<img width="1442" height="692" alt="image" src="https://github.com/user-attachments/assets/f7ca1979-70f9-4d4a-b246-644ee3791978" />

| Before | After |
|---|---|
|<img width="200" height="150" alt="image" src="https://github.com/user-attachments/assets/5c3eba3e-f1df-4929-9d70-a5e63352a66a" /> | <img width="200" height="150" alt="image" src="https://github.com/user-attachments/assets/1bb00dba-d364-49c6-ace7-cf5678556633" />|