### PR TITLE
Change runtime from edge to nodejs

### DIFF
--- a/pages/api/social-image.tsx
+++ b/pages/api/social-image.tsx
@@ -17,7 +17,7 @@ import { mapImageUrl } from '@/lib/map-image-url'
 import { notion } from '@/lib/notion-api'
 import { type NotionPageInfo, type PageError } from '@/lib/types'
 
-export const runtime = 'edge'
+export const runtime = 'nodejs'
 
 export default async function OGImage(
   req: NextApiRequest,


### PR DESCRIPTION
#### Description

Changed the Runtime to Nodejs to get higher limits in vercel deployment. Edge Functions has a 1 MB limit but Nodejs Function has a Limit of 50 MB